### PR TITLE
Fix ReactDOM import for React 18

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
 
-ReactDOM.createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- update `src/main.jsx` to use `createRoot` from `react-dom/client`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686daea1a92c832492a147d57982883e